### PR TITLE
refactor(cmd): rename test function and update logo output method

### DIFF
--- a/cmd/__snapshots__/root_test.snap
+++ b/cmd/__snapshots__/root_test.snap
@@ -1,5 +1,16 @@
 
-[TestRootCmd_NoArgs_ShowsHelp - 1]
+[TestExecute_ShowsHelp - 1]
+                    __ ______     _ __
+                   / //_/ __/__ _(_) /
+                  / ,< _\ \/ _ `/ / /
+                 /_/|_/___/\_,_/_/_/
+                                   . . .
+              __/___                 :
+        _____/______|             ___|____     |"\/"|
+_______/_____\_______\_____     ,'        `.    \  /
+\   -----       -\-\-\-    |    |  ^        \___/  |
+~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~
+
 KSail helps you easily create, manage, and test local Kubernetes clusters and workloads from one simple command line tool.
 
 Usage:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/devantler-tech/ksail-go/cmd/ui/asciiart"
 	"github.com/spf13/cobra"
@@ -55,7 +54,7 @@ func Execute(cmd *cobra.Command) error {
 
 // handleRootRunE handles the root command.
 func handleRootRunE(cmd *cobra.Command, _ []string) error {
-	asciiart.PrintKSailLogo(os.Stdout)
+	asciiart.PrintKSailLogo(cmd.OutOrStdout())
 
 	// The err can safely be ignored, as it can never fail at runtime.
 	_ = cmd.Help()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -44,7 +44,7 @@ func TestNewRootCmd_VersionFormatting(test *testing.T) {
 	}
 }
 
-func TestRootCmd_NoArgs_ShowsHelp(test *testing.T) {
+func TestExecute_ShowsHelp(test *testing.T) {
 	// Arrange
 	test.Parallel()
 


### PR DESCRIPTION
Rename the test function for clarity and update the method used to output the logo to improve flexibility in command output.