### PR TITLE
chore: add ClusterProvisioner interface for managing Kubernetes clusters

### DIFF
--- a/pkg/provisioner/cluster/doc.go
+++ b/pkg/provisioner/cluster/doc.go
@@ -1,0 +1,2 @@
+// Package clusterprovisioner provides an interface for managing Kubernetes clusters.
+package clusterprovisioner

--- a/pkg/provisioner/cluster/doc.go
+++ b/pkg/provisioner/cluster/doc.go
@@ -1,2 +1,0 @@
-// Package clusterprovisioner provides an interface for managing Kubernetes clusters.
-package clusterprovisioner

--- a/pkg/provisioner/cluster/provisioner.go
+++ b/pkg/provisioner/cluster/provisioner.go
@@ -1,0 +1,22 @@
+package clusterprovisioner
+
+// ClusterProvisioner defines methods for managing Kubernetes clusters.
+type ClusterProvisioner interface {
+	// Create creates a Kubernetes cluster. If name is non-empty, target that name; otherwise use config defaults.
+	Create(name string) error
+
+	// Delete deletes a Kubernetes cluster by name or config default when name is empty.
+	Delete(name string) error
+
+	// Start starts a Kubernetes cluster by name or config default when name is empty.
+	Start(name string) error
+
+	// Stop stops a Kubernetes cluster by name or config default when name is empty.
+	Stop(name string) error
+
+	// List lists all Kubernetes clusters.
+	List() ([]string, error)
+
+	// Exists checks if a Kubernetes cluster exists by name or config default when name is empty.
+	Exists(name string) (bool, error)
+}

--- a/pkg/provisioner/cluster/provisioner.go
+++ b/pkg/provisioner/cluster/provisioner.go
@@ -1,3 +1,4 @@
+// Package clusterprovisioner provides an interface for managing Kubernetes clusters.
 package clusterprovisioner
 
 // ClusterProvisioner defines methods for managing Kubernetes clusters.


### PR DESCRIPTION
Introduce the ClusterProvisioner interface to define methods for creating, deleting, starting, stopping, listing, and checking the existence of Kubernetes clusters.