### PR TITLE
chore: add installation steps for Mockery and update PATH in Copilot setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -47,3 +47,10 @@ jobs:
 
       - name: Install Go dependencies
         run: go mod download
+
+      - name: Install Mockery
+        run: |
+          go install github.com/vektra/mockery/v3@v3.5.4
+
+      - name: Add Go bin to PATH
+        run: echo "$HOME/go/bin" >> $GITHUB_PATH

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -49,8 +49,7 @@ jobs:
         run: go mod download
 
       - name: Install Mockery
-        run: |
-          go install github.com/vektra/mockery/v3@v3.5.4
+        run: go install github.com/vektra/mockery/v3@v3.5.4
 
       - name: Add Go bin to PATH
-        run: echo "$HOME/go/bin" >> $GITHUB_PATH
+        run: echo "$HOME/go/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
Include installation steps for Mockery and update the PATH to include the Go bin directory in the Copilot setup.