### PR TITLE
feat(init): add ksail init command

### DIFF
--- a/specs/002-add-the-ksail/spec.md
+++ b/specs/002-add-the-ksail/spec.md
@@ -1,0 +1,132 @@
+# Feature Specification: KSail Init Command
+
+**Feature Branch**: `002-add-the-ksail`
+**Created**: 2025-09-26
+**Status**: Draft
+**Input**: User description: "add the ksail init command with intuitive and nice CLI UX. This is important to make it easy for users to get started with ksail."
+
+## Execution Flow (main)
+
+```txt
+1. Parse user description from Input
+   → Feature: CLI command for project initialization
+2. Extract key concepts from description
+   → Actors: KSail users (developers, platform engineers)
+   → Actions: Initialize new Kubernetes projects, scaffold configuration files
+   → Data: Configuration files, project templates
+   → Constraints: Must be intuitive, easy to use for beginners
+3. For each unclear aspect:
+   → [No major clarifications needed - init command purpose is clear]
+4. Fill User Scenarios & Testing section
+   → Primary flow: User runs init in empty directory, gets working project
+5. Generate Functional Requirements
+   → Command execution, file generation, user feedback, error handling
+6. Identify Key Entities
+   → Project configuration, scaffold templates, CLI command interface
+7. Run Review Checklist
+   → Requirements testable, user-focused, no implementation details
+8. Return: SUCCESS (spec ready for planning)
+```
+
+---
+
+## ⚡ Quick Guidelines
+
+- ✅ Focus on WHAT users need and WHY
+- ❌ Avoid HOW to implement (no tech stack, APIs, code structure)
+- 👥 Written for business stakeholders, not developers
+
+---
+
+## Clarifications
+
+### Session 2025-09-26
+
+- Q: What should be the default Kubernetes distribution when user runs `ksail init` without flags? → A: Kind (local Docker-based clusters)
+- Q: When `ksail init` detects existing project files, what should be the default conflict resolution behavior? → A: Abort with error message (safest, requires --force)
+- Q: Which features should require network connectivity (if any) during `ksail init`? → A: None - completely offline operation always
+- Q: Should `ksail init` provide different initialization experiences for different user types? → A: No - single unified experience for all users
+- Q: What type of progress feedback should `ksail init` provide during the 5-second initialization? → A: Spinner with file creation messages
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### Primary User Story
+
+Any user (developer, platform engineer, or DevOps practitioner) wants to start using KSail for local Kubernetes development but doesn't know how to set up the initial project structure. They run `ksail init` in an empty directory and receive a fully configured project with all necessary files and clear next steps.
+
+### Acceptance Scenarios
+
+1. **Given** an empty directory, **When** user runs `ksail init`, **Then** system shows spinner with file creation messages, creates all required configuration files, and displays success message with next steps
+2. **Given** a directory with existing KSail files, **When** user runs `ksail init`, **Then** system aborts with error message explaining --force requirement
+3. **Given** user wants custom project settings, **When** user runs `ksail init` with flags, **Then** system respects those preferences in generated configuration
+4. **Given** user runs init in existing KSail project, **When** command executes, **Then** system detects existing project and offers to update or recreate configuration
+5. **Given** insufficient permissions to write files, **When** user runs `ksail init`, **Then** system displays clear error message explaining permission requirements
+
+### Edge Cases
+
+- What happens when disk space is insufficient for file creation?
+- How does system handle corrupted or missing embedded templates?
+- What occurs if user interrupts the init process mid-execution?
+- How does system behave with invalid directory names or special characters?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a `ksail init` command that scaffolds a new Kubernetes project
+- **FR-002**: Command MUST create a `ksail.yaml` configuration file with Kind as the default distribution
+- **FR-003**: Command MUST generate kind.yaml by default, with other distribution files (k3d.yaml, talos configs) only when explicitly specified
+- **FR-004**: Command MUST create a basic Kustomize structure with `k8s/kustomization.yaml`
+- **FR-005**: Command MUST display a spinner with "Initializing project..." text and show each file creation below the spinner
+- **FR-006**: Command MUST offer customization options through CLI flags (name, distribution, reconciliation tool, etc.)
+- **FR-007**: Command MUST detect existing project files and abort with clear error message unless --force flag is used
+- **FR-008**: Command MUST provide a `--force` flag to overwrite existing files when explicitly requested
+- **FR-009**: Command MUST display helpful next steps after successful initialization
+- **FR-010**: Command MUST validate user inputs and provide actionable error messages for invalid options
+- **FR-011**: System MUST support multiple Kubernetes distributions (Kind, K3d, Talos)
+- **FR-012**: System MUST optionally generate SOPS configuration for secret management
+- **FR-013**: Command MUST complete initialization within 5 seconds for typical projects
+- **FR-014**: Command MUST work completely offline with no network dependencies for any initialization features
+- **FR-015**: Command MUST provide comprehensive help text explaining all available options
+
+### Key Entities *(include if feature involves data)*
+
+- **Project Configuration**: Represents the KSail project settings including name, distribution choice, and feature selections
+- **Scaffold Template**: Represents the file templates and directory structure used to generate new projects
+- **CLI Command Interface**: Represents the command-line interface including flags, arguments, and user interaction patterns
+- **Distribution Config**: Represents the specific configuration files needed for each Kubernetes distribution (Kind, K3d, Talos)
+
+---
+
+## Review & Acceptance Checklist
+
+### Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+### Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+---
+
+## Execution Status
+
+- [x] User description parsed
+- [x] Key concepts extracted
+- [x] Ambiguities marked
+- [x] User scenarios defined
+- [x] Requirements generated
+- [x] Entities identified
+- [x] Review checklist passed
+
+---


### PR DESCRIPTION
Introduce a comprehensive feature specification for the `ksail init` command, detailing user scenarios, functional requirements, and execution flow to enhance user experience in initializing Kubernetes projects.