### PR TITLE
feat(cluster): implement `ksail cluster up` command with Kind, K3d, and EKS support

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,15 +1,13 @@
 <!--
 Sync Impact Report:
-- Version change: Template → 1.0.0 (Initial constitution creation)
-- Added principles:
-  - I. Code Quality Excellence
-  - II. Testing Standards (TDD-First)
-  - III. User Experience Consistency
-  - IV. Performance Requirements
-- Added sections:
-  - Quality Gates
-  - Development Standards
-- Templates requiring updates: All templates are aligned ✅
+- Version change: 1.0.0 → 1.1.0 (performance instrumentation mandate)
+- Modified principles:
+  - IV. Performance Requirements (inline telemetry requirement)
+- Added sections: None
+- Removed sections: None
+- Templates requiring updates:
+  - .specify/templates/plan-template.md ✅
+  - .specify/templates/tasks-template.md ✅
 - Follow-up TODOs: None
 -->
 
@@ -37,7 +35,7 @@ Rationale: Users rely on KSail-Go for critical infrastructure operations. Incons
 
 ### IV. Performance Requirements
 
-Operations MUST complete within defined performance thresholds: cluster validation <100ms, configuration loading <50ms, CLI response time <200ms, memory usage <50MB during normal operations. Operations must emit lightweight and tightly integrated timing telemetry (e.g., local vs total durations) so bottlenecks can be identified without dedicated benchmarking suites. Resource consumption MUST be measured and optimized continuously.
+Operations MUST complete within defined performance thresholds: cluster validation <100ms, configuration loading <50ms, CLI response time <200ms, memory usage <50MB during normal operations. Operations MUST emit lightweight and tightly integrated timing telemetry (e.g., local vs total durations) so bottlenecks can be identified without dedicated benchmarking suites. Resource consumption MUST be measured and optimized continuously.
 
 Rationale: KSail-Go operates in developer workflows where performance directly impacts productivity. Inline instrumentation keeps the experience responsive while avoiding benchmark bloat and still exposing actionable performance signals.
 
@@ -70,4 +68,4 @@ Amendment procedure: Proposed changes require documented rationale, impact analy
 
 Compliance review: All features undergo constitutional compliance review during design phase and implementation review. Non-compliance blocks release until resolved.
 
-**Version**: 1.0.0 | **Ratified**: 2025-09-24 | **Last Amended**: 2025-09-24
+**Version**: 1.1.0 | **Ratified**: 2025-09-24 | **Last Amended**: 2025-09-28

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -25,7 +25,7 @@ Rationale: As a developer tool managing critical Kubernetes infrastructure, KSai
 
 ### II. Testing Standards (TDD-First)
 
-Test-Driven Development is NON-NEGOTIABLE. Tests MUST be written before implementation, following the strict Red-Green-Refactor cycle. All public APIs require contract tests, all business logic requires unit tests with >90% coverage, and all integrations require end-to-end tests. No feature ships without comprehensive test coverage.
+Test-Driven Development is NON-NEGOTIABLE. Tests MUST be written before implementation, following the strict Red-Green-Refactor cycle. All public APIs require contract tests, all business logic requires unit tests with >90% coverage, and system-level integration coverage is enforced via the CI workflows in `.github/workflows/ci.yaml`. Local development focuses on unit and contract suites, while CI system runs provide the end-to-end verification gate. No feature ships without comprehensive unit/contract coverage and green CI system tests.
 
 Rationale: Managing Kubernetes clusters involves complex state management and critical operations. Comprehensive testing prevents production failures and ensures reliable behavior across diverse deployment scenarios.
 
@@ -37,9 +37,9 @@ Rationale: Users rely on KSail-Go for critical infrastructure operations. Incons
 
 ### IV. Performance Requirements
 
-Operations MUST complete within defined performance thresholds: cluster validation <100ms, configuration loading <50ms, CLI response time <200ms, memory usage <50MB during normal operations. All performance-critical paths require benchmarking and optimization. Resource consumption MUST be measured and optimized continuously.
+Operations MUST complete within defined performance thresholds: cluster validation <100ms, configuration loading <50ms, CLI response time <200ms, memory usage <50MB during normal operations. Operations must emit lightweight and tightly integrated timing telemetry (e.g., local vs total durations) so bottlenecks can be identified without dedicated benchmarking suites. Resource consumption MUST be measured and optimized continuously.
 
-Rationale: KSail-Go operates in developer workflows where performance directly impacts productivity. Slow tools disrupt flow state and reduce adoption. Performance requirements ensure responsive, efficient operations.
+Rationale: KSail-Go operates in developer workflows where performance directly impacts productivity. Inline instrumentation keeps the experience responsive while avoiding benchmark bloat and still exposing actionable performance signals.
 
 ## Quality Gates
 
@@ -47,7 +47,7 @@ All code changes MUST pass these mandatory gates before merge:
 
 - golangci-lint run returns zero issues
 - go test ./... achieves >90% coverage with all tests passing
-- Performance benchmarks meet defined thresholds
+- Instrumented runtime telemetry demonstrates thresholds are respected
 - Manual testing of CLI workflows completes successfully
 - Documentation updates accompany feature changes
 

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -34,14 +34,14 @@
 [Extract from feature spec: primary requirement + technical approach from research]
 
 ## Technical Context
-**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
-**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
-**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
-**Project Type**: [single/web/mobile - determines source structure]  
-**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
-**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Project Type**: [single/web/mobile - determines source structure]
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]
 **Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
 
 ## Constitution Check
@@ -144,7 +144,11 @@ ios/ or android/
    - Each story → integration test scenario
    - Quickstart test = story validation steps
 
-5. **Update agent file incrementally** (O(1) operation):
+5. **Plan inline performance instrumentation**:
+   - Identify key stages needing local vs total duration tracking
+   - Define how timing data surfaces through existing UX/logging patterns without introducing heavy benchmarking harnesses
+
+6. **Update agent file incrementally** (O(1) operation):
    - Run `.specify/scripts/bash/update-agent-context.sh copilot`
      **IMPORTANT**: Execute it exactly as specified above. Do not add or remove any arguments.
    - If exists: Add only NEW tech from current plan
@@ -159,15 +163,18 @@ ios/ or android/
 *This section describes what the /tasks command will do - DO NOT execute during /plan*
 
 **Task Generation Strategy**:
+
 - Load `.specify/templates/tasks-template.md` as base
 - Generate tasks from Phase 1 design docs (contracts, data model, quickstart)
 - Each contract → contract test task [P]
-- Each entity → model creation task [P] 
+- Each entity → model creation task [P]
 - Each user story → integration test task
+- Add instrumentation tasks to capture runtime telemetry when constitution requires it
 - Implementation tasks to make tests pass
 
 **Ordering Strategy**:
-- TDD order: Tests before implementation 
+
+- TDD order: Tests before implementation
 - Dependency order: Models before services before UI
 - Mark [P] for parallel execution (independent files)
 
@@ -178,9 +185,9 @@ ios/ or android/
 ## Phase 3+: Future Implementation
 *These phases are beyond the scope of the /plan command*
 
-**Phase 3**: Task execution (/tasks command creates tasks.md)  
-**Phase 4**: Implementation (execute tasks.md following constitutional principles)  
-**Phase 5**: Validation (run tests, execute quickstart.md, performance validation)
+**Phase 3**: Task execution (/tasks command creates tasks.md)
+**Phase 4**: Implementation (execute tasks.md following constitutional principles)
+**Phase 5**: Validation (run tests, execute quickstart.md, review telemetry outputs against performance thresholds)
 
 ## Complexity Tracking
 *Fill ONLY if Constitution Check has violations that must be justified*
@@ -195,6 +202,7 @@ ios/ or android/
 *This checklist is updated during execution flow*
 
 **Phase Status**:
+
 - [ ] Phase 0: Research complete (/plan command)
 - [ ] Phase 1: Design complete (/plan command)
 - [ ] Phase 2: Task planning complete (/plan command - describe approach only)
@@ -203,10 +211,11 @@ ios/ or android/
 - [ ] Phase 5: Validation passed
 
 **Gate Status**:
+
 - [ ] Initial Constitution Check: PASS
 - [ ] Post-Design Constitution Check: PASS
 - [ ] All NEEDS CLARIFICATION resolved
 - [ ] Complexity deviations documented
 
 ---
-*Based on Constitution v2.1.1 - See `/memory/constitution.md`*
+*Based on Constitution v1.1.0 - See `/memory/constitution.md`*

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -4,6 +4,7 @@
 **Prerequisites**: plan.md (required), research.md, data-model.md, contracts/
 
 ## Execution Flow (main)
+
 ```
 1. Load plan.md from feature directory
    → If not found: ERROR "No implementation plan found"
@@ -17,7 +18,8 @@
    → Tests: contract tests, integration tests
    → Core: models, services, CLI commands
    → Integration: DB, middleware, logging
-   → Polish: unit tests, performance, docs
+   → Telemetry: inline instrumentation or timing summaries per constitution
+   → Polish: unit tests, docs, manual verification
 4. Apply task rules:
    → Different files = mark [P] for parallel
    → Same file = sequential (no [P])
@@ -33,28 +35,34 @@
 ```
 
 ## Format: `[ID] [P?] Description`
+
 - **[P]**: Can run in parallel (different files, no dependencies)
 - Include exact file paths in descriptions
 
 ## Path Conventions
+
 - **Single project**: `src/`, `tests/` at repository root
 - **Web app**: `backend/src/`, `frontend/src/`
 - **Mobile**: `api/src/`, `ios/src/` or `android/src/`
 - Paths shown below assume single project - adjust based on plan.md structure
 
 ## Phase 3.1: Setup
+
 - [ ] T001 Create project structure per implementation plan
 - [ ] T002 Initialize [language] project with [framework] dependencies
 - [ ] T003 [P] Configure linting and formatting tools
 
 ## Phase 3.2: Tests First (TDD) ⚠️ MUST COMPLETE BEFORE 3.3
+
 **CRITICAL: These tests MUST be written and MUST FAIL before ANY implementation**
+
 - [ ] T004 [P] Contract test POST /api/users in tests/contract/test_users_post.py
 - [ ] T005 [P] Contract test GET /api/users/{id} in tests/contract/test_users_get.py
 - [ ] T006 [P] Integration test user registration in tests/integration/test_registration.py
 - [ ] T007 [P] Integration test auth flow in tests/integration/test_auth.py
 
 ## Phase 3.3: Core Implementation (ONLY after tests are failing)
+
 - [ ] T008 [P] User model in src/models/user.py
 - [ ] T009 [P] UserService CRUD in src/services/user_service.py
 - [ ] T010 [P] CLI --create-user in src/cli/user_commands.py
@@ -64,26 +72,30 @@
 - [ ] T014 Error handling and logging
 
 ## Phase 3.4: Integration
+
 - [ ] T015 Connect UserService to DB
 - [ ] T016 Auth middleware
 - [ ] T017 Request/response logging
 - [ ] T018 CORS and security headers
 
 ## Phase 3.5: Polish
+
 - [ ] T019 [P] Unit tests for validation in tests/unit/test_validation.py
-- [ ] T020 Performance tests (<200ms)
+- [ ] T020 Capture and review inline telemetry summary (local vs total durations)
 - [ ] T021 [P] Update docs/api.md
 - [ ] T022 Remove duplication
 - [ ] T023 Run manual-testing.md
 
 ## Dependencies
+
 - Tests (T004-T007) before implementation (T008-T014)
 - T008 blocks T009, T015
 - T016 blocks T018
 - Implementation before polish (T019-T023)
 
 ## Parallel Example
-```
+
+```bash
 # Launch T004-T007 together:
 Task: "Contract test POST /api/users in tests/contract/test_users_post.py"
 Task: "Contract test GET /api/users/{id} in tests/contract/test_users_get.py"
@@ -92,22 +104,24 @@ Task: "Integration test auth in tests/integration/test_auth.py"
 ```
 
 ## Notes
+
 - [P] tasks = different files, no dependencies
 - Verify tests fail before implementing
 - Commit after each task
 - Avoid: vague tasks, same file conflicts
 
 ## Task Generation Rules
-*Applied during main() execution*
+
+Applied during main() execution
 
 1. **From Contracts**:
    - Each contract file → contract test task [P]
    - Each endpoint → implementation task
-   
+
 2. **From Data Model**:
    - Each entity → model creation task [P]
    - Relationships → service layer tasks
-   
+
 3. **From User Stories**:
    - Each story → integration test [P]
    - Quickstart scenarios → validation tasks
@@ -117,6 +131,7 @@ Task: "Integration test auth in tests/integration/test_auth.py"
    - Dependencies block parallel execution
 
 ## Validation Checklist
+
 *GATE: Checked by main() before returning*
 
 - [ ] All contracts have corresponding tests
@@ -125,3 +140,4 @@ Task: "Integration test auth in tests/integration/test_auth.py"
 - [ ] Parallel tasks truly independent
 - [ ] Each task specifies exact file path
 - [ ] No task modifies same file as another [P] task
+- [ ] Telemetry tasks present when constitution performance requirements apply

--- a/specs/005-implement-the-description/contracts/cluster-up.md
+++ b/specs/005-implement-the-description/contracts/cluster-up.md
@@ -1,0 +1,75 @@
+# Contract: `ksail cluster up`
+
+## Invocation
+
+- **Command**: `ksail cluster up`
+- **Required config**: Valid `ksail.yaml` with `spec.distribution`, `spec.distributionConfig`, and distribution-specific YAML present.
+- **Flags**:
+  - `--distribution` (string, optional) – overrides `spec.distribution`; allowed values: `Kind`, `K3d`, `EKS`.
+  - `--distribution-config` (string, optional) – overrides `spec.distributionConfig` path.
+  - `--context` (string, optional) – overrides target kube context name.
+  - `--timeout` (duration, optional, default `5m`) – upper bound for provisioning + readiness.
+  - `--force` (bool, optional, default `false`) – delete/recreate existing cluster when true; otherwise reuse.
+
+## Inputs
+
+| Source | Description |
+|--------|-------------|
+| KSail cluster spec | Provides distribution selection, kubeconfig path, context, timeout, and optional AWS profile. |
+| Distribution config file | Supplies provider-specific parameters (Kind: `kind.yaml`, K3d: `k3d.yaml`, EKS: `eks.yaml`). |
+| Environment | Determines Docker/Podman availability (Kind/K3d) and AWS credentials/profile (EKS). |
+
+## Behavior
+
+1. Load KSail config via `configmanager.NewConfigManager` and validate through `ksailvalidator`.
+2. Resolve distribution-specific config using the matching config manager and validator.
+3. Perform dependency checks:
+   - Kind/K3d: verify Docker/Podman reachable via `containerengine.GetAutoDetectedClient()`.
+   - EKS: verify AWS credentials using default credential chain or optional `awsProfile`.
+4. Instantiate the matching `clusterprovisioner.ClusterProvisioner` implementation.
+5. If `--force` is true and the cluster exists, delete and recreate; otherwise reuse existing cluster when found.
+6. Call `Create` (or `Start` if reusing) and wait for kubeconfig/context to become available.
+7. Wait for Kubernetes readiness (nodes Ready and API responsive) within the timeout window.
+8. Ensure kubeconfig merged and set the command context as current.
+9. Emit structured success output including cluster name, distribution, context, kubeconfig path, duration.
+
+## Outputs
+
+### Human-readable (stdout)
+
+```text
+✅ Cluster "kind-kind" is ready
+   Distribution : Kind
+   Context      : kind-kind
+   Kubeconfig   : /Users/alex/.kube/config
+   Duration     : 2m41s
+```
+
+### Machine-readable (stdout when `--output json` is supported in future)
+
+```json
+{
+  "clusterName": "kind-kind",
+  "distribution": "Kind",
+  "context": "kind-kind",
+  "kubeconfigPath": "/Users/alex/.kube/config",
+  "ready": true,
+  "durationSeconds": 161
+}
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Provisioning succeeded and readiness verified. |
+| `1` | Validation failure (ksail config or distribution config invalid). |
+| `2` | Dependency failure (container engine or AWS credentials missing). |
+| `3` | Provisioner returned error while creating cluster. |
+| `4` | Readiness check timed out. |
+
+## Error Messaging Conventions
+
+- Include actionable remediation (e.g., "Start Docker and rerun `ksail cluster up`").
+- Surface original provider errors as contextual detail while preserving KSail-specific prefix.
+- On timeout, recommend rerunning with `--timeout` override and include partial status gathered during wait.

--- a/specs/005-implement-the-description/data-model.md
+++ b/specs/005-implement-the-description/data-model.md
@@ -1,0 +1,48 @@
+# Phase 1 Data Model – KSail Cluster Up Command
+
+## Entity: KSail Cluster Spec (`v1alpha1.Cluster`)
+
+| Field | Type | Description | Notes |
+|-------|------|-------------|-------|
+| `spec.distribution` | `Distribution` enum (`Kind`, `K3d`, `EKS`) | Selects the provisioner implementation. | Must be validated before executing the command. |
+| `spec.distributionConfig` | `string` | Path to distribution-specific config file (kind.yaml, k3d.yaml, eks.yaml). | Resolved relative to workspace using config-manager helpers. |
+| `spec.connection.kubeconfig` | `string` | Kubeconfig path to merge/update after provisioning. | Defaults to `~/.kube/config`; expanded via `pathutils`. |
+| `spec.connection.context` | `string` | Expected kube context name after provisioning. | Used to switch active context and to validate readiness. |
+| `spec.connection.timeout` | `metav1.Duration` | Upper bound for provisioning + readiness waits. | Defaults to 5 minutes; flag-overridable. |
+| `spec.options.eks.awsProfile` | `string` | Optional AWS profile for eksctl. | When empty rely on ambient credentials. |
+
+## Entity: Distribution Configs
+
+| Config | Loader | Key Fields consumed during `cluster up` |
+|--------|--------|-----------------------------------------|
+| Kind (`v1alpha4.Cluster`) | `kind.NewConfigManager` | `Name`, networking/node settings needed for provider. |
+| K3d (`v1alpha5.SimpleConfig`) | `k3d.NewConfigManager` | `Name`, server/agent counts, kubeconfig options. |
+| EKS (`eksctl.ClusterConfig`) | `eks.NewConfigManager` | `Metadata.Name`, `Metadata.Region`, node group definitions for scaling readiness. |
+
+## Entity: Dependency Check Result
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `engineReady` | `bool` | True when Docker/Podman reachable (Kind/K3d only). |
+| `engineName` | `string` | Friendly engine label from `containerengine.ContainerEngine`. |
+| `awsCredentialsReady` | `bool` | True when AWS credential chain resolves (EKS only). |
+| `messages` | `[]string` | Actionable error or success messages for CLI output. |
+
+## Entity: Provisioning Outcome
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `clusterName` | `string` | Effective cluster name used by provider. |
+| `distribution` | `string` | Distribution key for reporting (Kind/K3d/EKS). |
+| `kubeconfigPath` | `string` | Resolved kubeconfig location after merge. |
+| `context` | `string` | Active context set by the command. |
+| `ready` | `bool` | Indicates readiness wait succeeded. |
+| `duration` | `time.Duration` | Total time from provisioning start to readiness success. |
+
+## Entity: Readiness Probe Configuration
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timeout` | `time.Duration` | Upper bound for wait loop (default 5m). |
+| `pollInterval` | `time.Duration` | Interval between Kubernetes readiness checks (default 5s). |
+| `successCriteria` | `struct` | At minimum: all schedule-able nodes `Ready` and default namespace reachable. |

--- a/specs/005-implement-the-description/data-model.md
+++ b/specs/005-implement-the-description/data-model.md
@@ -19,7 +19,7 @@
 | K3d (`v1alpha5.SimpleConfig`) | `k3d.NewConfigManager` | `Name`, server/agent counts, kubeconfig options. |
 | EKS (`eksctl.ClusterConfig`) | `eks.NewConfigManager` | `Metadata.Name`, `Metadata.Region`, node group definitions for scaling readiness. |
 
-## Entity: Dependency Check Result
+## Entity: Dependency Check Result (command-local struct)
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -28,7 +28,7 @@
 | `awsCredentialsReady` | `bool` | True when AWS credential chain resolves (EKS only). |
 | `messages` | `[]string` | Actionable error or success messages for CLI output. |
 
-## Entity: Provisioning Outcome
+## Entity: Provisioning Outcome (command-local struct)
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -39,7 +39,7 @@
 | `ready` | `bool` | Indicates readiness wait succeeded. |
 | `duration` | `time.Duration` | Total time from provisioning start to readiness success. |
 
-## Entity: Readiness Probe Configuration
+## Entity: Readiness Probe Configuration (command-local struct)
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/specs/005-implement-the-description/plan.md
+++ b/specs/005-implement-the-description/plan.md
@@ -1,11 +1,11 @@
+
 # Implementation Plan: KSail Cluster Provisioning Command
 
 **Branch**: `005-implement-the-description` | **Date**: 2025-09-28 | **Spec**: `/Users/ndam/git-personal/monorepo/projects/ksail-go/specs/005-implement-the-description/spec.md`
 **Input**: Feature specification from `/specs/005-implement-the-description/spec.md`
 
 ## Execution Flow (/plan command scope)
-
-```text
+```
 1. Load feature spec from Input path
    → If not found: ERROR "No feature spec at {path}"
 2. Fill Technical Context (scan for NEEDS CLARIFICATION)
@@ -27,34 +27,34 @@
 ```
 
 **IMPORTANT**: The /plan command STOPS at step 7. Phases 2-4 are executed by other commands:
-
 - Phase 2: /tasks command creates tasks.md
 - Phase 3-4: Implementation execution (manual or via tools)
 
 ## Summary
 
-Deliver a production-ready `ksail cluster up` command that provisions Kind, K3d, or EKS clusters from an existing KSail project configuration. The command will reuse established config managers and cluster provisioner implementations, add explicit dependency and readiness verification, and guarantee kubeconfig activation before returning success. Research confirms we can rely on container engine detection utilities, eksctl-backed provisioners, and client-go readiness polling to satisfy the clarified requirements.
+Deliver a production-ready `ksail cluster up` command that provisions Kind, K3d, or EKS clusters using the existing KSail configuration pipeline. The command will reuse current config managers and provisioners, execute explicit dependency and readiness checks, and emit inline telemetry (slowest stage vs total runtime) through the notify/provisioner helpers—all implemented inside `cmd/cluster/up` without introducing a new orchestration package.
 
 ## Technical Context
 
-**Language/Version**: Go 1.24+ (current toolchain go1.25.1)
-**Primary Dependencies**: Cobra CLI, Viper, KSail config managers, `pkg/provisioner/cluster` (Kind/K3d/EKS), `pkg/provisioner/containerengine`, `k8s.io/client-go`, AWS SDK v2 config loader (transitively via eksctl)
-**Storage**: N/A — reads YAML configuration only
-**Testing**: `go test` with `testify` mocks/helpers; maintain TDD discipline
-**Target Platform**: Developer workstations (macOS/Linux) provisioning local Kind/K3d or AWS EKS clusters
-**Project Type**: Single CLI project (Option 1 structure)
-**Performance Goals**: Command should complete within configured timeout (default 5 min) and keep dependency checks <200 ms per constitution
-**Constraints**: Enforce readiness timeout, ensure dependency failures surface actionable errors, switch kubeconfig without manual edits, keep CLI output consistent with notify helpers
-**Scale/Scope**: One cluster per invocation across Kind/K3d/EKS distributions with optional `--force` recreation
+**Language/Version**: Go 1.25.1 (constitution requires ≥1.24)
+**Primary Dependencies**: Cobra CLI, Viper, `pkg/config-manager/{kind,k3d,eks}`, `pkg/provisioner/cluster/{kind,k3d,eks}`, `pkg/provisioner/containerengine`, `k8s.io/client-go`, AWS SDK v2 via eksctl wrappers, `internal/utils/path`
+**Storage**: N/A (reads project YAML configs only)
+**Testing**: `go test` (with testify mocks/helpers), go tool cover, golangci-lint; benchmarks replaced by inline telemetry validations
+**Target Platform**: macOS/Linux developer workstations provisioning local (Kind/K3d) or AWS EKS clusters
+**Project Type**: Single CLI project driven from `cmd/` and `pkg/`
+**Performance Goals**: CLI response <200 ms for dependency/validation stages, readiness capped at configurable timeout (default 5 min), telemetry must capture per-stage and total durations
+**Constraints**: Reuse existing provisioners, honour FR-007 force semantics, keep orchestration confined to `cmd/cluster/up`, fail fast on missing prerequisites, merge kubeconfig and switch context automatically, instrumentation must not spam or require extra output modes
+**Scale/Scope**: One cluster per invocation across Kind/K3d/EKS; minimal footprint for telemetry to keep UX responsive
 
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-- **Code Quality Excellence** → Plan confines orchestration to an injectable runner, enabling high test coverage and lint compliance.
-- **Testing Standards (TDD-First)** → All new functionality will start with failing tests (command wiring, runner logic, dependency failure, readiness timeout, kubeconfig switching) before implementation.
-- **User Experience Consistency** → CLI output will continue using `notify` helpers; flag naming aligns with existing conventions; error messages include remediation guidance.
-- **Performance Requirements** → Readiness waiter uses context deadlines with 5 s polling; dependency checks short-circuit quickly; no unnecessary blocking operations introduced.
+- **I. Code Quality Excellence** → Plan keeps orchestration in `cmd/cluster/up` using well-factored helper functions for configuration loading, dependency checks, telemetry, and readiness, enabling focused unit coverage while avoiding new packages.
+- **II. Testing Standards (TDD-First)** → All new behaviour (dependency checks, readiness waits, telemetry summaries, CLI wiring) will start with failing tests before implementation and maintain >90 % coverage.
+- **III. User Experience Consistency** → Command continues to use existing notify/provisioner helpers, supports the clarified `--force` semantics, and surfaces actionable remediation messages.
+ios/ or android/
+- **IV. Performance Requirements** → Inline timers capture local-stage and total durations, enforcing thresholds without external benchmarks and giving operators immediate visibility into slow steps.
 
 ## Project Structure
 
@@ -62,155 +62,159 @@ Deliver a production-ready `ksail cluster up` command that provisions Kind, K3d,
 
 ```text
 specs/005-implement-the-description/
-├── plan.md              # This file (/plan output)
-├── research.md          # Phase 0 output (/plan)
-├── data-model.md        # Phase 1 output (/plan)
-├── quickstart.md        # Phase 1 output (/plan)
-├── contracts/           # Phase 1 output (/plan)
-└── tasks.md             # Phase 2 output (/tasks)
+├── plan.md              # This file (/plan command output)
+├── research.md          # Phase 0 output (/plan command)
+├── data-model.md        # Phase 1 output (/plan command)
+├── quickstart.md        # Phase 1 output (/plan command)
+├── contracts/           # Phase 1 output (/plan command)
+└── tasks.md             # Phase 2 output (/tasks command - NOT created by /plan)
 ```
 
 ### Source Code (repository root)
 
 ```text
-# Option 1: Single project (DEFAULT)
 cmd/
 ├── cluster/
-│   └── up.go
+│   ├── cluster.go
+│   └── up.go              # houses all orchestration helpers and telemetry logic
 pkg/
-├── clusterup/           # new orchestration package
-├── provisioner/
 ├── config-manager/
-└── ...
+├── provisioner/
+│   └── cluster/{kind,k3d,eks}
+├── provisioner/containerengine
+├── io/
+└── validator/
 
 internal/
 └── testutils/
 
+.github/
+└── workflows/ci.yaml      # enforces system-level coverage
 ```
 
-**Structure Decision**: Option 1 (single CLI project). New orchestration helpers live in `pkg/clusterup` with minimal updates to existing command files.
+**Structure Decision**: Option 1 (single CLI). All orchestration stays inside `cmd/cluster/up` behind file-scoped helpers (config loading, dependency checks, telemetry recording, provisioning, readiness, kubeconfig management) so no new packages are introduced.
 
 ## Phase 0: Outline & Research
 
-- Reused provisioner/config manager approach validated; no new provider abstractions required.
-- Resolved dependency handling by leveraging existing container engine detection and AWS SDK profile loading.
-- Selected client-go readiness polling strategy to meet FR-008/FR-011.
-- Outcomes and alternatives captured in `research.md` (complete).
+- Reused provisioners/config managers confirmed to satisfy current interfaces (see `research.md`).
+- Established dependency checks via `containerengine.AutoDetect` and AWS SDK credential resolution to honour FR-009.
+- Selected client-go readiness polling (nodes Ready + namespace reachability) to meet FR-008/FR-011.
+- Validated kubeconfig merging via `clientcmd` helpers and post-provision verification.
+- Determined inline telemetry as primary performance signal: capture timestamps at dependency validation, provisioning start/stop, readiness wait, kubeconfig merge.
+
+**Output**: `/specs/005-implement-the-description/research.md` (complete).
 
 ## Phase 1: Design & Contracts
 
-Prerequisite: `research.md` complete.
+Prerequisite: research.md complete.
 
 ### Orchestration Design
 
-- Introduce `pkg/clusterup.Runner` composed of configuration loader, distribution config factory, dependency validator, provisioner resolver, readiness waiter, and kubeconfig manager.
-- Runner invoked by `cmd/cluster/up` with CLI options (timeout override, force recreation).
+- Keep all orchestration logic inside `cmd/cluster/up`, introducing file-scoped helper functions (e.g., `loadConfig`, `checkDependencies`, `recordTelemetry`, `provisionCluster`, `waitForReadiness`, `finalizeKubeconfig`).
+- Define small structs within the command file (such as `dependencyCheckResult`, `telemetrySummary`) to group related data without exporting new packages.
+- CLI handler (`NewUpCommand`/`runClusterUp`) remains the entry point, wiring helpers together and delegating output to `notify` helpers.
 
 ### Control Flow
 
-1. Load KSail project context (`ksail.yaml` + distribution config).
-2. Run dependency checks (container engine for Kind/K3d, AWS credentials for EKS).
-3. Acquire provisioner; inspect existing cluster state via `Exists`/`Status`.
-4. Branch on `--force` + existence: reuse (`Start`) or delete/create accordingly.
-5. Merge kubeconfig and activate context using `clientcmd.ModifyConfig`.
-6. Track timing checkpoints for each major stage (dependency checks, provisioning, readiness wait, kubeconfig merge) while executing them.
-7. Wait for readiness: poll nodes Ready + API healthy within timeout.
-8. Emit success through existing provisioner logging/notify helpers, appending the recorded total duration and slowest stage, and surface remediation-focused errors when something fails.
+1. Load KSail project context (`ksail.yaml` + distribution-specific overlays) via config manager interfaces.
+2. Resolve and validate dependencies: container engine availability for Kind/K3d, AWS credentials/profile for EKS.
+3. Start telemetry scope (record `commandStart`).
+4. Inspect provider state; if cluster exists and no `--force`, reuse; otherwise delete/create as needed.
+5. Capture per-stage timestamps (`dependencyDuration`, `provisionDuration`, `readinessDuration`, `kubeconfigDuration`).
+6. Merge kubeconfig and set active context using `clientcmd.ModifyConfig` or existing provisioner helpers.
+7. Wait for readiness (poll nodes and namespace) respecting timeout.
+8. On success, emit notify/provisioner output augmented with concise telemetry summary (`slowestStage`, `totalDuration`). On failure, emit actionable guidance and attempt cleanup when safe.
 
 ### Dependency Validation
 
-- Kind/K3d: `containerengine.AutoDetect` ensures Docker/Podman reachable.
-- EKS: AWS SDK `config.LoadDefaultConfig` (respecting profile) and `cfg.Credentials.Retrieve` to guarantee access before provisioning.
+- Kind/K3d: use `containerengine.AutoDetect` and check for running daemon socket. Provide remediation (`Start Docker/Podman`).
+- EKS: load AWS config (`config.LoadDefaultConfig`), ensure credentials retrieved, and highlight missing profile/permission issues.
+
+### Runtime Instrumentation
+
+- Implement a lightweight telemetry helper struct inside `cmd/cluster/up` to capture labelled durations and compute slowest stage + total runtime.
+- Ensure telemetry respects quiet/JSON modes by embedding summary within existing notify output (e.g., `success: ... • slowest stage: readiness=3m12s • total: 3m25s`).
+- Provide hooks so tests can inject fake clocks (via function parameters or interfaces) for deterministic assertions.
 
 ### Readiness Waiter
 
-- Build rest config from kubeconfig path/context.
-- Poll every 5 seconds using client-go until nodes Ready and namespace accessible.
-- Respect context deadline; timeout yields exit code 4 per contract.
+- Build rest config using resolved kubeconfig context.
+- Poll every 5 s: ensure all schedulable nodes Ready and default namespace accessible; fail with timeout after configured limit.
+- Differentiate between transient API errors and fatal conditions for actionable messaging.
 
 ### Kubeconfig Management
 
-- Use `clientcmd.Load` to inspect contexts, add/update context entries, and persist via `clientcmd.ModifyConfig`.
-- Maintain safe write semantics via existing IO helpers.
+- Confirm expected context exists after provisioning; create/update entries using `clientcmd.ModifyConfig` when necessary.
+- Guard writes with file locking or safe write helper from `pkg/io`.
 
-### Testing Strategy (TDD)
-
-- `cmd/cluster/up_test.go`: flag wiring, runner invocation, force path, timeout parsing, error propagation, confirmation that success output leverages existing notify/provisioner helpers without echoing flag values, and assertions around the timing summary content (local vs total durations).
-- `pkg/clusterup/runner_test.go`: mocks for config loaders, provisioners, dependency checker, readiness waiter, kubeconfig updater, and verification that runner delegates success messaging to the notify/provisioner helpers while emitting the timing summary.
-- `pkg/clusterup/dependencies_test.go`: container engine/AWS credential scenarios produce actionable errors.
-- `pkg/clusterup/readiness_test.go`: fake clientset covers ready/timeout cases.
-- `pkg/clusterup/kubeconfig_test.go`: ensure context switching persists correctly (temp filesystem).
-
-System-level scenarios are validated by CI workflows in `.github/workflows/ci.yaml`, so this feature focuses on unit and contract coverage in-repo, with local execution enforcing >90% coverage via `go test` against a generated profile.
-
-### Performance Instrumentation
-
-- Introduce lightweight timers inside the runner to capture per-stage durations and total command runtime.
-- Surface a concise summary (e.g., `slowest stage: readiness=3m12s • total=3m25s`) via existing notify helpers on success to help developers spot bottlenecks without stand-alone benchmarks.
-- Ensure instrumentation paths remain opt-out capable for scripting (respect quiet/JSON modes) while still recording metrics internally for potential future aggregation.
-
-### Artifacts Generated
-
-- `data-model.md`, `contracts/cluster-up.md`, and `quickstart.md` complete and lint clean.
-- Agent context update pending after finalizing plan.
+- `cmd/cluster/up_test.go`: covers flag wiring, dependency failure messaging, readiness timeout exit codes, telemetry summary content, force semantics, and kubeconfig switching (using helper functions where necessary).
+- `cmd/cluster/up_internal_test.go`: exercises file-scoped helpers for dependency checks, readiness waits (with fake clientsets), telemetry calculations, and kubeconfig persistence using temp directories.
 
 ### Agent Context Update
 
-- Run `.specify/scripts/bash/update-agent-context.sh copilot` post-plan to keep assistant guidance current.
+- `.specify/scripts/bash/update-agent-context.sh copilot` executed on 2025-09-28 to sync guidance with the updated plan; rerun if significant dependencies change later.
+
+**Output**: `/specs/005-implement-the-description/data-model.md`, `/specs/005-implement-the-description/contracts/`, `/specs/005-implement-the-description/quickstart.md` (all complete), plus agent context update (pending run).
 
 ## Phase 2: Task Planning Approach
 
-This section describes what the /tasks command will do. Do not execute it during `/plan`.
+This section describes what the /tasks command will do - DO NOT execute during /plan
 
-### Task Generation Strategy
+- Load `.specify/templates/tasks-template.md` as base.
+- Seed setup + shared fixtures tasks (command helper scaffolding, testdata for kubeconfig/AWS stubs).
+- Create failing tests for dependency checks, readiness waiter, kubeconfig manager, telemetry helper, and CLI wiring—all within the `cmd/cluster` package.
+- Add implementation tasks for helper functions, dependency logic, readiness waiter, kubeconfig updates, telemetry helper, and CLI integration inside `cmd/cluster/up.go`.
+- Include integration tasks for wiring helper seams (dependency injection via function parameters) and ensuring existing provisioners are invoked correctly.
+- Generate polish tasks for docs, gofmt/go test/go tool cover, golangci-lint, telemetry review, and manual quickstart validation capturing emitted telemetry summary.
 
-- Seed tasks from contracts, data model, and design notes (tests first, implementation second).
-- Create dedicated tasks for new packages (`pkg/clusterup`) covering dependency checker, runner, readiness waiter, and kubeconfig manager.
-- Include CLI wiring, documentation updates, and validation commands (build, test, lint).
+**Ordering Strategy**:
 
-### Ordering Strategy
+- Strict TDD order: author failing tests before implementation for each component.
+- Implement helpers in dependency order (config loader → dependency checker → readiness → kubeconfig → telemetry → runner → CLI).
+- Mark independent test cases ([P]) when they target separate files.
+- Reserve polish tasks until after integration, ensuring telemetry review occurs alongside manual quickstart run.
 
-- Begin with unit tests for CLI and runner, then dependency/readiness helper tests.
-- Implement helper packages in dependency order to satisfy the failing tests.
-- Mark independent suites (readiness vs dependency checker) with `[P]` for potential parallel execution.
+**Estimated Output**: ~21 tasks (already captured in `tasks.md`) covering setup, tests, implementation, integration, telemetry, docs, and validation.
 
-**Estimated Output**: Approximately 20–25 ordered tasks captured in `tasks.md`.
+**IMPORTANT**: This phase is executed by the /tasks command, NOT by /plan.
 
 ## Phase 3+: Future Implementation
 
-Beyond the scope of the `/plan` command:
+These phases are beyond the scope of the /plan command
 
-- **Phase 3**: Generate `tasks.md` via /tasks command.
-- **Phase 4**: Execute implementation tasks adhering to constitution (TDD, lint, docs).
-- **Phase 5**: Run full validation (tests, quickstart walkthrough, readiness smoke).
+**Phase 3**: Task execution (/tasks command creates tasks.md)
+**Phase 4**: Implementation (execute tasks.md following constitutional principles)
+**Phase 5**: Validation (run tests, execute quickstart.md, review telemetry outputs against performance thresholds)
 
 ## Complexity Tracking
 
-Fill this section only if the constitution check has violations that must be justified.
+Fill ONLY if Constitution Check has violations that must be justified
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |
 |-----------|------------|-------------------------------------|
-| None      | —          | —                                   |
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+
 
 ## Progress Tracking
 
-This checklist is updated during execution flow.
+This checklist is updated during execution flow
 
-### Phase Status
+**Phase Status**:
 
 - [x] Phase 0: Research complete (/plan command)
 - [x] Phase 1: Design complete (/plan command)
-- [ ] Phase 2: Task planning complete (/plan command - describe approach only)
+- [x] Phase 2: Task planning complete (/plan command - describe approach only)
 - [ ] Phase 3: Tasks generated (/tasks command)
 - [ ] Phase 4: Implementation complete
 - [ ] Phase 5: Validation passed
 
-### Gate Status
+**Gate Status**:
 
 - [x] Initial Constitution Check: PASS
 - [x] Post-Design Constitution Check: PASS
 - [x] All NEEDS CLARIFICATION resolved
-- [x] Complexity deviations documented (none required)
+- [x] Complexity deviations documented
 
 ---
-*Based on Constitution v2.1.1 - See `/memory/constitution.md`*
+*Based on Constitution v1.1.0 - See `/memory/constitution.md`*

--- a/specs/005-implement-the-description/plan.md
+++ b/specs/005-implement-the-description/plan.md
@@ -1,0 +1,216 @@
+# Implementation Plan: KSail Cluster Provisioning Command
+
+**Branch**: `005-implement-the-description` | **Date**: 2025-09-28 | **Spec**: `/Users/ndam/git-personal/monorepo/projects/ksail-go/specs/005-implement-the-description/spec.md`
+**Input**: Feature specification from `/specs/005-implement-the-description/spec.md`
+
+## Execution Flow (/plan command scope)
+
+```text
+1. Load feature spec from Input path
+   → If not found: ERROR "No feature spec at {path}"
+2. Fill Technical Context (scan for NEEDS CLARIFICATION)
+   → Detect Project Type from context (web=frontend+backend, mobile=app+api)
+   → Set Structure Decision based on project type
+3. Fill the Constitution Check section based on the content of the constitution document.
+4. Evaluate Constitution Check section below
+   → If violations exist: Document in Complexity Tracking
+   → If no justification possible: ERROR "Simplify approach first"
+   → Update Progress Tracking: Initial Constitution Check
+5. Execute Phase 0 → research.md
+   → If NEEDS CLARIFICATION remain: ERROR "Resolve unknowns"
+6. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, `GEMINI.md` for Gemini CLI, `QWEN.md` for Qwen Code or `AGENTS.md` for opencode).
+7. Re-evaluate Constitution Check section
+   → If new violations: Refactor design, return to Phase 1
+   → Update Progress Tracking: Post-Design Constitution Check
+8. Plan Phase 2 → Describe task generation approach (DO NOT create tasks.md)
+9. STOP - Ready for /tasks command
+```
+
+**IMPORTANT**: The /plan command STOPS at step 7. Phases 2-4 are executed by other commands:
+
+- Phase 2: /tasks command creates tasks.md
+- Phase 3-4: Implementation execution (manual or via tools)
+
+## Summary
+
+Deliver a production-ready `ksail cluster up` command that provisions Kind, K3d, or EKS clusters from an existing KSail project configuration. The command will reuse established config managers and cluster provisioner implementations, add explicit dependency and readiness verification, and guarantee kubeconfig activation before returning success. Research confirms we can rely on container engine detection utilities, eksctl-backed provisioners, and client-go readiness polling to satisfy the clarified requirements.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (current toolchain go1.25.1)
+**Primary Dependencies**: Cobra CLI, Viper, KSail config managers, `pkg/provisioner/cluster` (Kind/K3d/EKS), `pkg/provisioner/containerengine`, `k8s.io/client-go`, AWS SDK v2 config loader (transitively via eksctl)
+**Storage**: N/A — reads YAML configuration only
+**Testing**: `go test` with `testify` mocks/helpers; maintain TDD discipline
+**Target Platform**: Developer workstations (macOS/Linux) provisioning local Kind/K3d or AWS EKS clusters
+**Project Type**: Single CLI project (Option 1 structure)
+**Performance Goals**: Command should complete within configured timeout (default 5 min) and keep dependency checks <200 ms per constitution
+**Constraints**: Enforce readiness timeout, ensure dependency failures surface actionable errors, switch kubeconfig without manual edits, keep CLI output consistent with notify helpers
+**Scale/Scope**: One cluster per invocation across Kind/K3d/EKS distributions with optional `--force` recreation
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Code Quality Excellence** → Plan confines orchestration to an injectable runner, enabling high test coverage and lint compliance.
+- **Testing Standards (TDD-First)** → All new functionality will start with failing tests (command wiring, runner logic, dependency failure, readiness timeout, kubeconfig switching) before implementation.
+- **User Experience Consistency** → CLI output will continue using `notify` helpers; flag naming aligns with existing conventions; error messages include remediation guidance.
+- **Performance Requirements** → Readiness waiter uses context deadlines with 5 s polling; dependency checks short-circuit quickly; no unnecessary blocking operations introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-implement-the-description/
+├── plan.md              # This file (/plan output)
+├── research.md          # Phase 0 output (/plan)
+├── data-model.md        # Phase 1 output (/plan)
+├── quickstart.md        # Phase 1 output (/plan)
+├── contracts/           # Phase 1 output (/plan)
+└── tasks.md             # Phase 2 output (/tasks)
+```
+
+### Source Code (repository root)
+
+```text
+# Option 1: Single project (DEFAULT)
+cmd/
+├── cluster/
+│   └── up.go
+pkg/
+├── clusterup/           # new orchestration package
+├── provisioner/
+├── config-manager/
+└── ...
+
+internal/
+└── testutils/
+
+```
+
+**Structure Decision**: Option 1 (single CLI project). New orchestration helpers live in `pkg/clusterup` with minimal updates to existing command files.
+
+## Phase 0: Outline & Research
+
+- Reused provisioner/config manager approach validated; no new provider abstractions required.
+- Resolved dependency handling by leveraging existing container engine detection and AWS SDK profile loading.
+- Selected client-go readiness polling strategy to meet FR-008/FR-011.
+- Outcomes and alternatives captured in `research.md` (complete).
+
+## Phase 1: Design & Contracts
+
+Prerequisite: `research.md` complete.
+
+### Orchestration Design
+
+- Introduce `pkg/clusterup.Runner` composed of configuration loader, distribution config factory, dependency validator, provisioner resolver, readiness waiter, and kubeconfig manager.
+- Runner invoked by `cmd/cluster/up` with CLI options (timeout override, force recreation).
+
+### Control Flow
+
+1. Load KSail project context (`ksail.yaml` + distribution config).
+2. Run dependency checks (container engine for Kind/K3d, AWS credentials for EKS).
+3. Acquire provisioner; inspect existing cluster state via `Exists`/`Status`.
+4. Branch on `--force` + existence: reuse (`Start`) or delete/create accordingly.
+5. Merge kubeconfig and activate context using `clientcmd.ModifyConfig`.
+6. Track timing checkpoints for each major stage (dependency checks, provisioning, readiness wait, kubeconfig merge) while executing them.
+7. Wait for readiness: poll nodes Ready + API healthy within timeout.
+8. Emit success through existing provisioner logging/notify helpers, appending the recorded total duration and slowest stage, and surface remediation-focused errors when something fails.
+
+### Dependency Validation
+
+- Kind/K3d: `containerengine.AutoDetect` ensures Docker/Podman reachable.
+- EKS: AWS SDK `config.LoadDefaultConfig` (respecting profile) and `cfg.Credentials.Retrieve` to guarantee access before provisioning.
+
+### Readiness Waiter
+
+- Build rest config from kubeconfig path/context.
+- Poll every 5 seconds using client-go until nodes Ready and namespace accessible.
+- Respect context deadline; timeout yields exit code 4 per contract.
+
+### Kubeconfig Management
+
+- Use `clientcmd.Load` to inspect contexts, add/update context entries, and persist via `clientcmd.ModifyConfig`.
+- Maintain safe write semantics via existing IO helpers.
+
+### Testing Strategy (TDD)
+
+- `cmd/cluster/up_test.go`: flag wiring, runner invocation, force path, timeout parsing, error propagation, confirmation that success output leverages existing notify/provisioner helpers without echoing flag values, and assertions around the timing summary content (local vs total durations).
+- `pkg/clusterup/runner_test.go`: mocks for config loaders, provisioners, dependency checker, readiness waiter, kubeconfig updater, and verification that runner delegates success messaging to the notify/provisioner helpers while emitting the timing summary.
+- `pkg/clusterup/dependencies_test.go`: container engine/AWS credential scenarios produce actionable errors.
+- `pkg/clusterup/readiness_test.go`: fake clientset covers ready/timeout cases.
+- `pkg/clusterup/kubeconfig_test.go`: ensure context switching persists correctly (temp filesystem).
+
+System-level scenarios are validated by CI workflows in `.github/workflows/ci.yaml`, so this feature focuses on unit and contract coverage in-repo, with local execution enforcing >90% coverage via `go test` against a generated profile.
+
+### Performance Instrumentation
+
+- Introduce lightweight timers inside the runner to capture per-stage durations and total command runtime.
+- Surface a concise summary (e.g., `slowest stage: readiness=3m12s • total=3m25s`) via existing notify helpers on success to help developers spot bottlenecks without stand-alone benchmarks.
+- Ensure instrumentation paths remain opt-out capable for scripting (respect quiet/JSON modes) while still recording metrics internally for potential future aggregation.
+
+### Artifacts Generated
+
+- `data-model.md`, `contracts/cluster-up.md`, and `quickstart.md` complete and lint clean.
+- Agent context update pending after finalizing plan.
+
+### Agent Context Update
+
+- Run `.specify/scripts/bash/update-agent-context.sh copilot` post-plan to keep assistant guidance current.
+
+## Phase 2: Task Planning Approach
+
+This section describes what the /tasks command will do. Do not execute it during `/plan`.
+
+### Task Generation Strategy
+
+- Seed tasks from contracts, data model, and design notes (tests first, implementation second).
+- Create dedicated tasks for new packages (`pkg/clusterup`) covering dependency checker, runner, readiness waiter, and kubeconfig manager.
+- Include CLI wiring, documentation updates, and validation commands (build, test, lint).
+
+### Ordering Strategy
+
+- Begin with unit tests for CLI and runner, then dependency/readiness helper tests.
+- Implement helper packages in dependency order to satisfy the failing tests.
+- Mark independent suites (readiness vs dependency checker) with `[P]` for potential parallel execution.
+
+**Estimated Output**: Approximately 20–25 ordered tasks captured in `tasks.md`.
+
+## Phase 3+: Future Implementation
+
+Beyond the scope of the `/plan` command:
+
+- **Phase 3**: Generate `tasks.md` via /tasks command.
+- **Phase 4**: Execute implementation tasks adhering to constitution (TDD, lint, docs).
+- **Phase 5**: Run full validation (tests, quickstart walkthrough, readiness smoke).
+
+## Complexity Tracking
+
+Fill this section only if the constitution check has violations that must be justified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None      | —          | —                                   |
+
+## Progress Tracking
+
+This checklist is updated during execution flow.
+
+### Phase Status
+
+- [x] Phase 0: Research complete (/plan command)
+- [x] Phase 1: Design complete (/plan command)
+- [ ] Phase 2: Task planning complete (/plan command - describe approach only)
+- [ ] Phase 3: Tasks generated (/tasks command)
+- [ ] Phase 4: Implementation complete
+- [ ] Phase 5: Validation passed
+
+### Gate Status
+
+- [x] Initial Constitution Check: PASS
+- [x] Post-Design Constitution Check: PASS
+- [x] All NEEDS CLARIFICATION resolved
+- [x] Complexity deviations documented (none required)
+
+---
+*Based on Constitution v2.1.1 - See `/memory/constitution.md`*

--- a/specs/005-implement-the-description/quickstart.md
+++ b/specs/005-implement-the-description/quickstart.md
@@ -19,7 +19,7 @@
    ksail cluster up --distribution Kind
    ```
 
-4. Wait for the success message summarising distribution, context, kubeconfig, and duration.
+4. Wait for the success message summarising distribution, context, kubeconfig, slowest stage, and total duration.
 5. Verify the kube context switched:
 
    ```bash
@@ -42,7 +42,7 @@
    ksail cluster up --distribution K3d
    ```
 
-4. Confirm the CLI reports success and the context `k3d-<name>` is active.
+4. Confirm the CLI reports success with the timing summary and the context `k3d-<name>` is active.
 
 ## Steps (EKS example)
 
@@ -59,7 +59,7 @@
    ksail cluster up --distribution EKS --timeout 10m
    ```
 
-4. After success, verify the context and describe cluster health:
+4. After success, verify the timing summary, confirm the context, and describe cluster health:
 
    ```bash
    kubectl cluster-info

--- a/specs/005-implement-the-description/quickstart.md
+++ b/specs/005-implement-the-description/quickstart.md
@@ -1,0 +1,76 @@
+# Quickstart – KSail Cluster Up Command
+
+## Prerequisites
+
+- KSail project initialised with `ksail init` and populated `ksail.yaml`.
+- Distribution config present (e.g., `kind.yaml`, `k3d.yaml`, or `eks.yaml`).
+- Docker or Podman running for Kind/K3d workflows.
+- AWS CLI configured with working credentials/profile for EKS workflows.
+
+## Steps (Kind example)
+
+1. Ensure Docker is running: `docker ps`.
+2. Confirm KSail config targets Kind:
+   - `spec.distribution: Kind`
+   - `spec.distributionConfig: kind.yaml`
+3. Run the command:
+
+   ```bash
+   ksail cluster up --distribution Kind
+   ```
+
+4. Wait for the success message summarising distribution, context, kubeconfig, and duration.
+5. Verify the kube context switched:
+
+   ```bash
+   kubectl config current-context
+   ```
+
+6. Inspect cluster nodes to confirm readiness:
+
+   ```bash
+   kubectl get nodes
+   ```
+
+## Steps (K3d example)
+
+1. Start Docker or Podman.
+2. Populate `spec.distribution: K3d` and provide `k3d.yaml`.
+3. Execute:
+
+   ```bash
+   ksail cluster up --distribution K3d
+   ```
+
+4. Confirm the CLI reports success and the context `k3d-<name>` is active.
+
+## Steps (EKS example)
+
+1. Export the AWS profile if required:
+
+   ```bash
+   export AWS_PROFILE=infra-admin
+   ```
+
+2. Set `spec.distribution: EKS` and supply `eks.yaml` with region + node groups.
+3. Run:
+
+   ```bash
+   ksail cluster up --distribution EKS --timeout 10m
+   ```
+
+4. After success, verify the context and describe cluster health:
+
+   ```bash
+   kubectl cluster-info
+   ```
+
+## Force Recreation Flow
+
+- Use `--force` when you need a clean cluster reset:
+
+   ```bash
+   ksail cluster up --force
+   ```
+
+- The command deletes the existing cluster, reprovisions it, then waits for readiness before exiting.

--- a/specs/005-implement-the-description/research.md
+++ b/specs/005-implement-the-description/research.md
@@ -1,0 +1,36 @@
+# Phase 0 Research – KSail Cluster Up Command
+
+## Decision: Reuse existing distribution provisioners
+
+- **Rationale**: The repository already exposes dedicated implementations in `pkg/provisioner/cluster/{kind,k3d,eks}` that satisfy the shared `ClusterProvisioner` interface. Wiring these packages keeps logic consistent with other cluster lifecycle commands and avoids duplicating provider-specific code paths.
+- **Alternatives Considered**:
+  - Implementing distribution-specific logic directly inside the Cobra command. Rejected because it would splinter provisioning concerns and make dependency injection/testing harder.
+  - Introducing a new abstraction layer above `ClusterProvisioner`. Rejected for now; existing interface is sufficient and already covered by tests.
+
+## Decision: Load distribution configs via config managers
+
+- **Rationale**: `pkg/config-manager/{kind,k3d,eks}` already encapsulate YAML loading, defaulting, and validation against upstream schemas. Using them aligns with constitution requirements on validation and prevents bypassing safety checks the CLI depends on.
+- **Alternatives Considered**:
+  - Manually reading YAML using Viper or `io.ReadFile`. Rejected; would skip validation helpers and duplicate loader logic.
+  - Assuming defaults only for missing config files. Rejected because users expect explicit error messaging when config is malformed.
+
+## Decision: Dependency checks before provisioning
+
+- **Rationale**: `pkg/provisioner/containerengine` can detect Docker/Podman availability, and AWS profile/credential presence can be checked via environment using the standard AWS SDK credential chain. Failing fast honours the spec (FR-009) and the constitution’s reliability principle.
+- **Alternatives Considered**:
+  - Deferring failures to provider libraries (kind, k3d, eksctl). Rejected as it produces hard-to-action errors and violates the spec’s requirement for clear guidance.
+  - Attempting automatic installation of dependencies. Rejected for now; outside scope and risky. Guidance will direct users to install/enable prerequisites.
+
+## Decision: Cluster readiness verification strategy
+
+- **Rationale**: We can use client-go’s kubeconfig loader plus a lightweight wait loop over core APIs (e.g., `Nodes` ready condition) with the configured kubeconfig/context. This gives us a distribution-agnostic success signal and ensures the kubeconfig has been written before exit, satisfying FR-008 and FR-011.
+- **Alternatives Considered**:
+  - Shelling out to `kubectl wait`. Rejected to avoid external command dependencies and keep output consistent.
+  - Polling provider-specific health endpoints. Rejected because it fragments logic and fails to guarantee Kubernetes API readiness.
+
+## Decision: Kubeconfig merge and context switching
+
+- **Rationale**: Kind and k3d provisioners already update kubeconfig automatically when run with default options. To guarantee FR-010, we will verify after provisioning that the expected context exists and optionally call `clientcmd.ModifyConfig` to set it as current if needed. For EKS, we can rely on eksctl behaviour and then confirm context selection.
+- **Alternatives Considered**:
+  - Writing custom kubeconfig merge logic from scratch. Rejected in favour of using `clientcmd` helpers.
+  - Leaving context unchanged and printing manual steps. Rejected; contradicts clarified requirement.

--- a/specs/005-implement-the-description/spec.md
+++ b/specs/005-implement-the-description/spec.md
@@ -1,0 +1,81 @@
+# Feature Specification: KSail Cluster Provisioning Command
+
+**Feature Branch**: `005-implement-the-description`
+**Created**: 2025-09-28
+**Status**: Draft
+**Input**: User description: "Implement the `ksail cluster up` command to create a cluster based on the given ksail config. Make sure to support kind, k3d and eks distributions. The implementation must use existing packages."
+
+## Clarifications
+
+### Session 2025-09-28
+
+- Q: When `ksail cluster up` is invoked and the target cluster already exists for the chosen distribution, what outcome should we guarantee? → A: Recreate only when `--force` flag is supplied.
+- Q: Do we wait for the provisioned cluster to become Ready before reporting success? → A: Yes, wait for Ready and kubeconfig usability.
+- Q: If a required dependency (Docker daemon, AWS credentials) is missing at runtime, what should the command do? → A: Fail fast with a clear, actionable error.
+- Q: After creating or verifying a cluster, how should the command manage kubeconfig? → A: Merge/update kubeconfig and set the new context as current.
+- Q: What default timeout should apply while waiting for cluster readiness? → A: 5 minutes by default.
+
+## User Scenarios & Testing *(mandatory)*
+
+### Primary User Story
+
+A platform engineer uses the KSail CLI to bootstrap a local or cloud Kubernetes environment. They run `ksail cluster up`, and the tool provisions a cluster that matches the distribution and configuration declared in their KSail project settings so they can begin deploying workloads immediately.
+
+### Acceptance Scenarios
+
+1. **Given** a project with a valid KSail configuration targeting the Kind distribution, **When** the engineer runs `ksail cluster up`, **Then** a Kind cluster is provisioned with the configured name, networking, and add-ons, and the command reports success.
+2. **Given** a KSail configuration targeting either K3d or EKS and containing all required credentials or connection details, **When** the engineer runs `ksail cluster up`, **Then** the corresponding K3d or EKS cluster is created or brought to an active state, and the user receives feedback on completion or actionable errors if provisioning fails.
+
+### Edge Cases
+
+- What happens when the KSail configuration omits mandatory distribution details such as cluster name or region?
+- How does the system handle a request to create a cluster that already exists according to the chosen provider when the `--force` flag is absent or present?
+- How are partial failures reported when infrastructure prerequisites (e.g., Docker daemon, cloud credentials) are unavailable?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST load the active KSail project configuration before executing `ksail cluster up`, validating that a supported distribution is specified.
+- **FR-002**: The command MUST provision or start a Kind cluster when the configuration declares the Kind distribution, applying user-defined settings such as cluster name and node parameters.
+- **FR-003**: The command MUST provision or start a K3d cluster when the configuration declares the K3d distribution, honoring the configuration values relevant to K3d environments.
+- **FR-004**: The command MUST provision or start an EKS cluster when the configuration declares the EKS distribution, using the provided account, region, and cluster sizing information.
+- **FR-005**: The command MUST reuse existing KSail provisioning capabilities rather than introducing new distribution frameworks, ensuring consistent behavior with current lifecycle operations.
+- **FR-006**: The command MUST surface success using the existing provisioner/notify output streams, appending a concise timing summary that highlights both the overall command duration and the duration of individual steps. On failure, it MUST provide an actionable remediation hint (for example, "Start Docker and rerun the command") and confirm that no orphaned infrastructure remains when cleanup is feasible.
+- **FR-007**: The command MUST detect when the target cluster already exists, treating the operation as a readiness verification unless the user passes `--force`, in which case the cluster is recreated.
+- **FR-008**: The command MUST block until the provisioned cluster reports Ready status and the kubeconfig is usable before signaling success for Kind, K3d, and EKS distributions.
+- **FR-009**: The command MUST perform dependency checks and fail fast with explicit remediation guidance when prerequisites such as Docker daemons or cloud credentials are unavailable.
+- **FR-010**: The command MUST merge or update the user's kubeconfig with the cluster connection details and set the new cluster context as current upon successful completion.
+- **FR-011**: The command MUST enforce a default 5-minute timeout when waiting for cluster readiness, after which it fails with guidance unless the user overrides the timeout.
+
+### Key Entities
+
+- **KSail Project Configuration**: Defines the desired distribution (Kind, K3d, or EKS), cluster naming, sizing, and provider-specific options that drive provisioning behavior.
+- **Provisioning Response**: Represents the outcome of the cluster creation attempt, including success confirmation, contextual metadata (cluster name, endpoint), and any error messages presented to the user.
+
+## Review & Acceptance Checklist
+
+### Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+### Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Execution Status
+
+- [x] User description parsed
+- [x] Key concepts extracted
+- [x] Ambiguities marked
+- [x] User scenarios defined
+- [x] Requirements generated
+- [x] Entities identified
+- [x] Review checklist passed

--- a/specs/005-implement-the-description/tasks.md
+++ b/specs/005-implement-the-description/tasks.md
@@ -5,48 +5,48 @@
 
 ## Phase 3.1: Setup
 
-- [ ] T001 Create cluster up orchestration package skeleton (`pkg/clusterup/README.md`, `pkg/clusterup/doc.go`).
+- [ ] T001 Introduce helper scaffolding in `cmd/cluster/up.go` (type stubs for dependency results, telemetry summary, readiness config, TODO markers removed).
   - Dependencies: Implementation plan approved (`plan.md`)
-  - Notes: Document package intent and export guidelines without adding functional code.
-- [ ] T002 [P] Prepare shared test fixtures under `pkg/clusterup/testdata/` (kubeconfig templates, fake node payloads, AWS profile stubs).
+  - Notes: Keep logic within the command package; add doc comments outlining helper responsibilities.
+- [ ] T002 [P] Prepare shared test fixtures under `cmd/cluster/testdata/` (kubeconfig templates, fake node payloads, AWS profile stubs).
   - Dependencies: T001
-  - Notes: Provide reusable files referenced by dependency, readiness, and kubeconfig tests.
+  - Notes: Provide reusable files referenced by dependency, readiness, telemetry, and kubeconfig tests.
 
 ## Phase 3.2: Tests First (TDD)
 
-- [ ] T003 [P] Author failing dependency-check tests in `pkg/clusterup/dependencies_test.go` covering Docker/Podman detection and AWS credential errors.
+- [ ] T003 [P] Author failing dependency-check tests in `cmd/cluster/up_internal_test.go` covering Docker/Podman detection and AWS credential errors.
   - Dependencies: T001, T002
-- [ ] T004 [P] Author failing readiness waiter tests in `pkg/clusterup/readiness_test.go` for success, timeout, and API failure flows using fake clientsets.
+- [ ] T004 [P] Author failing readiness waiter tests in `cmd/cluster/up_internal_test.go` for success, timeout, and API failure flows using fake clientsets.
   - Dependencies: T001, T002
-- [ ] T005 [P] Author failing kubeconfig management tests in `pkg/clusterup/kubeconfig_test.go` validating context creation, switching, and persistence to disk.
+- [ ] T005 [P] Author failing kubeconfig management tests in `cmd/cluster/up_internal_test.go` validating context creation, switching, and persistence to disk.
   - Dependencies: T001, T002
-- [ ] T006 Author failing runner orchestration tests in `pkg/clusterup/runner_test.go` covering new cluster creation, reuse, force recreate, dependency failure, and readiness timeout.
+- [ ] T006 Author failing orchestration helper tests in `cmd/cluster/up_internal_test.go` covering new cluster creation, reuse, force recreate, dependency failure, readiness timeout, and telemetry integration.
   - Dependencies: T003, T004, T005
-- [ ] T007 [P] Expand `cmd/cluster/up_test.go` contract coverage for CLI flag wiring, runner invocation, dependency error messaging, readiness timeout exit codes, and confirmation that success output routes through existing notify/provisioner helpers.
+- [ ] T007 [P] Expand `cmd/cluster/up_test.go` coverage for CLI flag wiring, helper invocation, dependency error messaging, readiness timeout exit codes, and confirmation that success output routes through existing notify/provisioner helpers with telemetry summary.
   - Dependencies: T006
-- [ ] T008 [P] Add timing instrumentation tests in `pkg/clusterup/telemetry_test.go` (or within runner tests) to validate per-stage duration capture and summary formatting.
+- [ ] T008 [P] Add timing instrumentation tests in `cmd/cluster/up_internal_test.go` to validate per-stage duration capture, slowest-stage computation, and summary formatting (including quiet/JSON modes stubs).
   - Dependencies: T003, T004, T005
 
 ## Phase 3.3: Core Implementation (after tests are failing)
 
-- [ ] T009 Implement spec and distribution config loading helpers in `pkg/clusterup/config_loader.go` returning validated `v1alpha1.Cluster` and provider configs expected by runner tests.
+- [ ] T009 Implement config loading helpers in `cmd/cluster/up.go` returning validated `v1alpha1.Cluster` and provider configs expected by tests.
   - Dependencies: T006
-- [ ] T010 Implement dependency checking logic and `DependencyCheckResult` struct in `pkg/clusterup/dependencies.go` to satisfy T003 expectations.
+- [ ] T010 Implement dependency checking helper and `dependencyCheckResult` struct in `cmd/cluster/up.go` to satisfy T003 expectations.
   - Dependencies: T003
-- [ ] T011 Implement readiness waiter with `ReadinessProbeConfig` in `pkg/clusterup/readiness.go` using client-go polling to satisfy T004.
+- [ ] T011 Implement readiness waiter helper with `readinessProbeConfig` in `cmd/cluster/up.go` using client-go polling to satisfy T004.
   - Dependencies: T004
-- [ ] T012 Implement kubeconfig management utilities in `pkg/clusterup/kubeconfig.go` ensuring context creation and persistence to satisfy T005.
+- [ ] T012 Implement kubeconfig management helper in `cmd/cluster/up.go` ensuring context creation and persistence to satisfy T005.
   - Dependencies: T005
-- [ ] T013 Implement `Runner` orchestration, provisioner factory wiring, and `ProvisioningOutcome` struct in `pkg/clusterup/runner.go` to satisfy T006.
+- [ ] T013 Implement telemetry helper and orchestration flow in `cmd/cluster/up.go`, wiring provisioning logic, force semantics, and telemetry summary to satisfy T006/T008.
   - Dependencies: T009, T010, T011, T012
-- [ ] T014 Refactor `cmd/cluster/up.go` to invoke the runner, rely on existing notify/provisioner helpers for success messaging, and surface exit codes/errors expected by T007.
+- [ ] T014 Finalize CLI handler in `cmd/cluster/up.go` to parse flags, call helpers, and surface notify/provisioner output expected by T007.
   - Dependencies: T013, T007
 
 ## Phase 3.4: Integration
 
-- [ ] T015 Integrate runner injection seams for tests and command wiring (e.g., update `cmd/cluster/cluster.go` or supporting file) so CLI and benchmark harnesses can hook into the runner cleanly.
+- [ ] T015 Expose helper seams (function parameters/interfaces) inside `cmd/cluster/up.go` so tests can inject fakes while the CLI uses real provisioners and config managers.
   - Dependencies: T013, T007
-- [ ] T016 Connect runner factories to existing Kind, K3d, and EKS provisioners/config managers (e.g., `pkg/clusterup/factory.go`) ensuring real provisioning paths function.
+- [ ] T016 Validate real provisioner wiring in `cmd/cluster/up.go`, ensuring Kind/K3d/EKS paths invoke existing packages and respect `--force` semantics.
   - Dependencies: T013, T015
 
 ## Phase 3.5: Polish
@@ -63,8 +63,8 @@
 ## Dependencies
 
 - Tests (T003–T008) must be created and observed failing before implementation tasks (T009–T014).
-- Runner integration (T015–T016) builds on the completed runner implementation (T013) and CLI wiring (T014).
-- Timing instrumentation (T008) underpins the runtime summary surfaced by the runner and CLI.
+- Integration tasks (T015–T016) build on the completed helper implementations (T009–T014) and CLI wiring (T014).
+- Timing instrumentation (T008) underpins the runtime summary surfaced by the CLI.
 - Polish tasks (T017–T020) run only after all core and integration work is complete.
 
 ## Parallel Execution Example

--- a/specs/005-implement-the-description/tasks.md
+++ b/specs/005-implement-the-description/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: KSail Cluster Provisioning Command
+
+**Input**: Design documents from `/specs/005-implement-the-description/`
+**Prerequisites**: plan.md, research.md, data-model.md, contracts/cluster-up.md, quickstart.md
+
+## Phase 3.1: Setup
+
+- [ ] T001 Create cluster up orchestration package skeleton (`pkg/clusterup/README.md`, `pkg/clusterup/doc.go`).
+  - Dependencies: Implementation plan approved (`plan.md`)
+  - Notes: Document package intent and export guidelines without adding functional code.
+- [ ] T002 [P] Prepare shared test fixtures under `pkg/clusterup/testdata/` (kubeconfig templates, fake node payloads, AWS profile stubs).
+  - Dependencies: T001
+  - Notes: Provide reusable files referenced by dependency, readiness, and kubeconfig tests.
+
+## Phase 3.2: Tests First (TDD)
+
+- [ ] T003 [P] Author failing dependency-check tests in `pkg/clusterup/dependencies_test.go` covering Docker/Podman detection and AWS credential errors.
+  - Dependencies: T001, T002
+- [ ] T004 [P] Author failing readiness waiter tests in `pkg/clusterup/readiness_test.go` for success, timeout, and API failure flows using fake clientsets.
+  - Dependencies: T001, T002
+- [ ] T005 [P] Author failing kubeconfig management tests in `pkg/clusterup/kubeconfig_test.go` validating context creation, switching, and persistence to disk.
+  - Dependencies: T001, T002
+- [ ] T006 Author failing runner orchestration tests in `pkg/clusterup/runner_test.go` covering new cluster creation, reuse, force recreate, dependency failure, and readiness timeout.
+  - Dependencies: T003, T004, T005
+- [ ] T007 [P] Expand `cmd/cluster/up_test.go` contract coverage for CLI flag wiring, runner invocation, dependency error messaging, readiness timeout exit codes, and confirmation that success output routes through existing notify/provisioner helpers.
+  - Dependencies: T006
+- [ ] T008 [P] Add timing instrumentation tests in `pkg/clusterup/telemetry_test.go` (or within runner tests) to validate per-stage duration capture and summary formatting.
+  - Dependencies: T003, T004, T005
+
+## Phase 3.3: Core Implementation (after tests are failing)
+
+- [ ] T009 Implement spec and distribution config loading helpers in `pkg/clusterup/config_loader.go` returning validated `v1alpha1.Cluster` and provider configs expected by runner tests.
+  - Dependencies: T006
+- [ ] T010 Implement dependency checking logic and `DependencyCheckResult` struct in `pkg/clusterup/dependencies.go` to satisfy T003 expectations.
+  - Dependencies: T003
+- [ ] T011 Implement readiness waiter with `ReadinessProbeConfig` in `pkg/clusterup/readiness.go` using client-go polling to satisfy T004.
+  - Dependencies: T004
+- [ ] T012 Implement kubeconfig management utilities in `pkg/clusterup/kubeconfig.go` ensuring context creation and persistence to satisfy T005.
+  - Dependencies: T005
+- [ ] T013 Implement `Runner` orchestration, provisioner factory wiring, and `ProvisioningOutcome` struct in `pkg/clusterup/runner.go` to satisfy T006.
+  - Dependencies: T009, T010, T011, T012
+- [ ] T014 Refactor `cmd/cluster/up.go` to invoke the runner, rely on existing notify/provisioner helpers for success messaging, and surface exit codes/errors expected by T007.
+  - Dependencies: T013, T007
+
+## Phase 3.4: Integration
+
+- [ ] T015 Integrate runner injection seams for tests and command wiring (e.g., update `cmd/cluster/cluster.go` or supporting file) so CLI and benchmark harnesses can hook into the runner cleanly.
+  - Dependencies: T013, T007
+- [ ] T016 Connect runner factories to existing Kind, K3d, and EKS provisioners/config managers (e.g., `pkg/clusterup/factory.go`) ensuring real provisioning paths function.
+  - Dependencies: T013, T015
+
+## Phase 3.5: Polish
+
+- [ ] T017 [P] Update user-facing documentation (`README.md` and related sections) to reflect new `ksail cluster up` behaviour and quickstart guidance.
+  - Dependencies: T014, T016
+- [ ] T018 [P] Run `go test ./... -coverpkg=./... -coverprofile=coverage.out`, refresh generated artifacts (mocks/snaps), and fail the task if overall coverage drops below 90% (capture `go tool cover -func=coverage.out`).
+  - Dependencies: T009, T010, T011, T012, T013, T014, T015, T016
+- [ ] T019 [P] Run `golangci-lint run --timeout 5m` and resolve lint issues introduced by the feature.
+  - Dependencies: T018
+- [ ] T020 Execute manual verification steps from `specs/005-implement-the-description/quickstart.md` (dry-run commands, inspect outputs) and log outcomes in PR notes, capturing the timing summary output for reference.
+  - Dependencies: T017, T018, T019
+
+## Dependencies
+
+- Tests (T003–T008) must be created and observed failing before implementation tasks (T009–T014).
+- Runner integration (T015–T016) builds on the completed runner implementation (T013) and CLI wiring (T014).
+- Timing instrumentation (T008) underpins the runtime summary surfaced by the runner and CLI.
+- Polish tasks (T017–T020) run only after all core and integration work is complete.
+
+## Parallel Execution Example
+
+```bash
+task T003
+task T004
+task T005
+task T007
+task T008
+```


### PR DESCRIPTION
Introduce the `ksail cluster up` command to provision clusters using Kind, K3d, and EKS distributions. Update documentation to include detailed usage instructions and enhance performance requirements for inline telemetry. Version updated to 1.1.0.